### PR TITLE
Pass ContractUtxos down as props to keep state in sync

### DIFF
--- a/src/components/ContractFunction.tsx
+++ b/src/components/ContractFunction.tsx
@@ -8,11 +8,11 @@ interface Props {
   abi?: AbiFunction
   network: Network
   wallets: Wallet[]
-  utxos: Utxo[] | undefined
+  contractUtxos: Utxo[] | undefined
   updateUtxosContract: () => void
 }
 
-const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets, utxos, updateUtxosContract }) => {
+const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets, contractUtxos, updateUtxosContract }) => {
   const [args, setArgs] = useState<Argument[]>([])
   const [outputs, setOutputs] = useState<Recipient[]>([{ to: '', amount: 0n }])
   // transaction inputs, not the same as abi.inputs
@@ -32,10 +32,8 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets, ut
   useEffect(() => {
     if (!manualSelection) return;
     async function updateUtxos() {
-      if (contract === undefined || utxos === undefined) return
-      const utxosContract = utxos
-      console.log(utxosContract)
-      const namedUtxosContract: NamedUtxo[] = utxosContract.map((utxo, index) => ({ ...utxo, name: `Contract UTXO ${index}`, isP2pkh: false }))
+      if (contract === undefined || contractUtxos === undefined) return
+      const namedUtxosContract: NamedUtxo[] = contractUtxos.map((utxo, index) => ({ ...utxo, name: `Contract UTXO ${index}`, isP2pkh: false }))
       let newUtxoList = namedUtxosContract
       for (let i = 0; i < wallets.length; i++) {
         const utxosWallet = await new ElectrumNetworkProvider(network).getUtxos(wallets[i].address);
@@ -45,7 +43,7 @@ const ContractFunction: React.FC<Props> = ({ contract, abi, network, wallets, ut
       setUtxoList(newUtxoList);
     }
     updateUtxos()
-  }, [manualSelection, utxos])
+  }, [manualSelection, contractUtxos])
 
   function fillPrivKey(i: number, walletIndex: string) {
     const argsCopy = [...args];

--- a/src/components/ContractFunctions.tsx
+++ b/src/components/ContractFunctions.tsx
@@ -8,13 +8,13 @@ interface Props {
   contract?: Contract
   network: Network
   wallets: Wallet[]
-  utxos: Utxo[] | undefined
+  contractUtxos: Utxo[] | undefined
   updateUtxosContract: () => void
 }
 
-const ContractFunctions: React.FC<Props> = ({ artifact, contract, network, wallets, utxos, updateUtxosContract }) => {
+const ContractFunctions: React.FC<Props> = ({ artifact, contract, network, wallets, contractUtxos, updateUtxosContract }) => {
   const functions = artifact?.abi.map(func => (
-    <ContractFunction contract={contract} key={func.name} abi={func} network={network} wallets={wallets} utxos={utxos} updateUtxosContract={updateUtxosContract}/>
+    <ContractFunction contract={contract} key={func.name} abi={func} network={network} wallets={wallets} contractUtxos={contractUtxos} updateUtxosContract={updateUtxosContract}/>
   ))
 
   return (

--- a/src/components/ContractInfo.tsx
+++ b/src/components/ContractInfo.tsx
@@ -53,19 +53,13 @@ const ContractInfo: React.FC<Props> = ({ artifact, network, setNetwork, setShowW
     setUtxos(await contract.getUtxos())
   }
 
-  useEffect(() => {
-    setTimeout(() => {
-      updateUtxosContract()
-    }, 5000);
-  }, [updateUtxosContract]);
-
   return (
     <ColumnFlex
       id="preview"
       style={{ ...style, flex: 1, margin: '16px' }}
     >
       <ContractCreation artifact={artifact} contract={contract} setContract={setContract} network={network} setNetwork={setNetwork} setShowWallets={setShowWallets} utxos={utxos} balance={balance} updateUtxosContract={updateUtxosContract}/>
-      <ContractFunctions artifact={artifact} contract={contract} network={network} wallets={wallets} utxos={utxos} updateUtxosContract={updateUtxosContract} />
+      <ContractFunctions artifact={artifact} contract={contract} network={network} wallets={wallets} contractUtxos={utxos} updateUtxosContract={updateUtxosContract} />
     </ColumnFlex>
   )
 }

--- a/src/components/ContractInfo.tsx
+++ b/src/components/ContractInfo.tsx
@@ -3,6 +3,7 @@ import { Artifact, Contract, Network, Utxo } from 'cashscript'
 import { ColumnFlex, Wallet } from './shared'
 import ContractCreation from './ContractCreation'
 import ContractFunctions from './ContractFunctions'
+import { ElectrumClient, ElectrumTransport } from 'electrum-cash'
 
 interface Props {
   artifact?: Artifact
@@ -17,8 +18,34 @@ const ContractInfo: React.FC<Props> = ({ artifact, network, setNetwork, setShowW
   const [contract, setContract] = useState<Contract | undefined>(undefined)
   const [balance, setBalance] = useState<bigint | undefined>(undefined)
   const [utxos, setUtxos] = useState<Utxo[] | undefined>([])
+  const [electrumClient, setElectrumClient] = useState<ElectrumClient | undefined>(undefined)
 
   useEffect(() => setContract(undefined), [artifact])
+
+  async function initElectrumSubscription(){
+    if(electrumClient) electrumClient?.disconnect()
+    if(!contract?.address) return
+
+    // connect to ElectrumClient for subscription
+    let electrumServerName: string= ""
+    if(network == "mainnet") electrumServerName = 'bch.imaginary.cash'
+    if(network == "chipnet")electrumServerName = 'chipnet.imaginary.cash'
+    if(network == "testnet4") electrumServerName = 'testnet4.imaginary.cash'
+    if(!electrumServerName) return // no imaginary server for  testnet3
+    
+    const newElectrumClient = new ElectrumClient('Electrum client example', '1.4.1', electrumServerName, ElectrumTransport.WSS.Port, ElectrumTransport.WSS.Scheme)
+    await newElectrumClient?.connect();
+    // subscribe to contract address
+    const refetchContractBalance = async(data:any) => {
+      if(data) updateUtxosContract()
+    }
+    await newElectrumClient?.subscribe(refetchContractBalance, 'blockchain.address.subscribe', contract.address);
+    setElectrumClient(newElectrumClient)
+  }
+
+  useEffect(() => {
+    initElectrumSubscription()
+  }, [contract])
 
   async function updateUtxosContract () {
     if (!contract) return


### PR DESCRIPTION
ContractUtxos is now passed down from contractInfo to an individual ContractFunction so manual UTXO selection has access to an synchronized utxo list for the smart contract utxos